### PR TITLE
Change default value for tablature position, Do not write tab under tied notes

### DIFF
--- a/harmonica_tablature.qml
+++ b/harmonica_tablature.qml
@@ -100,7 +100,9 @@ MuseScore {
             }
         }
         ComboBox {
-            currentIndex: 1
+            currentIndex: 3
+			// Lower by default, prefered harp players' position
+			// Lower par défaut, position préférée des harmonicistes
             model: ListModel {
                 id: placetext
                 property var position
@@ -240,6 +242,7 @@ MuseScore {
                 text.text = "X";
             else {
 				if (notes[i].tieBack != null) {
+					// No tab if the note is tied
 					// Pas de tablature si la note est une note liée
 					tab = ""
 				} else if (bendChar !== "b") {

--- a/harmonica_tablature.qml
+++ b/harmonica_tablature.qml
@@ -239,8 +239,12 @@ MuseScore {
             if (typeof tab === "undefined")
                 text.text = "X";
             else {
-                if (bendChar !== "b")
+				if (notes[i].tieBack != null) {
+					// Pas de tablature si la note est une note liée
+					tab = ""
+				} else if (bendChar !== "b") {
                     tab = tab.replace(/b/g, bendChar);
+				}
                 text.text = tab + text.text;
                 }
         }

--- a/harmonica_tablature.qml
+++ b/harmonica_tablature.qml
@@ -17,8 +17,8 @@ import QtQuick.Layouts 1.1
 import MuseScore 1.0
 
 MuseScore {
-    version: "2.0"
-    description: "Harmonica Tab plugin"
+    version: "2.1"
+    description: "Harmonica Tab plugin\nhttps://github.com/lasconic/harmonica_tablature\nContributors: Lasconic, Thierz"
     menuPath: "Plugins.Harmonica Tablature"
     pluginType: "dialog"
 

--- a/harmonica_tablature.qml
+++ b/harmonica_tablature.qml
@@ -101,8 +101,8 @@ MuseScore {
         }
         ComboBox {
             currentIndex: 3
-			// Lower by default, prefered harp players' position
-			// Lower par défaut, position préférée des harmonicistes
+            // Lower by default, prefered harp players' position
+            // Lower par défaut, position préférée des harmonicistes
             model: ListModel {
                 id: placetext
                 property var position
@@ -241,13 +241,13 @@ MuseScore {
             if (typeof tab === "undefined")
                 text.text = "X";
             else {
-				if (notes[i].tieBack != null) {
-					// No tab if the note is tied
-					// Pas de tablature si la note est une note liée
-					tab = ""
-				} else if (bendChar !== "b") {
+                if (notes[i].tieBack != null) {
+                    // No tab if the note is tied
+                    // Pas de tablature si la note est une note liée
+                    tab = ""
+                } else if (bendChar !== "b") {
                     tab = tab.replace(/b/g, bendChar);
-				}
+                }
                 text.text = tab + text.text;
                 }
         }


### PR DESCRIPTION
Salut Nicolas,

Comme convenu je te propose mes modifications pour le plugin Harmonica Tablature :
* Le placement par défaut de la tablature devient "Lower" : pour en avoir parlé à plusieurs harmonicistes, ils choisissent tous cette position pour la tablature, et ça les arrange de ne pas avoir à changer cette valeur à chaque exécution. À terme, si tu n'es pas contre, on pourrait même enlever carrément cette option pour forcer "Lower" pour tout le monde.
* La tablature ne s'écrit pas sous les notes qui sont liées à la précédente.

A+

Thibibi alias Thierz