### PR TITLE
fix typos and improve wording in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-This is a plugin for MuseScore 3 to add harmonica tablature notation below the notes. It currently supports
+This is a plugin for MuseScore 3 to add harmonica tablature notation below the notes. It currently supports:
 
- * the Hohner Highlander only, for both side, A highlander and D - [Reference](http://musescore.org/sites/musescore.org/files/Hohner%20Highlander%20scale.jpg)
- * Diatonic A - [Reference](http://harmopoint.com/harmonica-virtuel/) [and for overblows and overdraws](http://www.overblow.com/?menuid=26)
- * Diatonic Bb - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oskar%20Diatonic%20Bb.jpg) [and for overblows and overdraws](http://www.overblow.com/?menuid=26)
- * Diatonic C - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oscar%20C.jpg) [and for overblows and overdraws](http://www.overblow.com/?menuid=26)
- * Diatonic D - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oskar%20Diatonic%20D.jpg) [and for overblows and overdraws](http://www.overblow.com/?menuid=26)
- * Diatonic F - [Reference](http://harmopoint.com/harmonica-virtuel/) [and for overblows and overdraws](http://www.overblow.com/?menuid=26)
- * Diatonic G - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oskar%20%20Diatonic%20G.jpg) [and for overblows and overdraws](http://www.overblow.com/?menuid=26)
+ * Hohner Highlander for both sides (A highlander and D) - [Reference](http://musescore.org/sites/musescore.org/files/Hohner%20Highlander%20scale.jpg)
+ * Diatonic A - [Reference](http://harmopoint.com/harmonica-virtuel/), [overblows and overdraws](http://www.overblow.com/?menuid=26)
+ * Diatonic Bb - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oskar%20Diatonic%20Bb.jpg), [overblows and overdraws](http://www.overblow.com/?menuid=26)
+ * Diatonic C - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oscar%20C.jpg), [overblows and overdraws](http://www.overblow.com/?menuid=26)
+ * Diatonic D - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oskar%20Diatonic%20D.jpg), [overblows and overdraws](http://www.overblow.com/?menuid=26)
+ * Diatonic F - [Reference](http://harmopoint.com/harmonica-virtuel/), [overblows and overdraws](http://www.overblow.com/?menuid=26)
+ * Diatonic G - [Reference](http://musescore.org/sites/musescore.org/files/Lee%20Oskar%20%20Diatonic%20G.jpg), [overblows and overdraws](http://www.overblow.com/?menuid=26)
  * Chromatic C, 12 holes - [Reference](http://musescore.org/sites/musescore.org/files/12%20Hole%20Chromatic%20slide%20Harmonica.txt)
  * Chromatic C, 16 holes - [Reference](https://coast2coastmusic.com/chromatic/tuning_charts.shtml)
 
 
-If you want to have your harmonica added to the it, please contact me, or better, do a pull request.
+If you want to have your harmonica added to it, please contact me, or even better, do a pull request.
 
 
-##Convention
+## Conventions
 * "+" = blow
 * "-" = draw
 * '  = halfstep bend
@@ -24,8 +24,8 @@ If you want to have your harmonica added to the it, please contact me, or better
 * -X? = overdraw
 * "<" = slide
 
-Bends, over blow, over draw may be supported if it's the only way to play the note.
-If there are two holes for one note, a choice has been made (draw)
+Bends, over blow, over draw may be supported if it's the only way to play the note. 
+If there are two holes for one note, a choice has been made to draw.
 
-##More info
+## More info
 See the official [project page](http://musescore.org/en/project/harmonicatablature)


### PR DESCRIPTION
I have fixed some wording and made the links clearer by making sure that the "reference" link does not immediately exfeed the "overblows and overdraws" link.
I also fixed the header formattings.